### PR TITLE
Add defect causing SpotBugs warning

### DIFF
--- a/src/main/java/net/benelog/BadMain.java
+++ b/src/main/java/net/benelog/BadMain.java
@@ -1,0 +1,11 @@
+package net.benelog;
+
+public class BadMain {
+	public static void main(String[] args) {
+		System.out.println(isNormal());
+	}
+
+	private static Boolean isNormal() {
+		return null;
+	}
+}


### PR DESCRIPTION
This PR causes the warning of [NP_BOOLEAN_RETURN_NULL](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#np-method-with-boolean-return-type-returns-explicit-null-np-boolean-return-null) by SpotBugs.